### PR TITLE
#1 Add GitHub actions

### DIFF
--- a/.github/workflow/codecov.yml
+++ b/.github/workflow/codecov.yml
@@ -1,0 +1,31 @@
+name: codecov
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  codecov:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
+      - run: |
+          mvn clean install
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./build/jacocoHtml/index.html
+          fail_ci_if_error: false


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a GitHub Actions workflow configuration for Codecov, enabling coverage reports to be uploaded after running Maven tests on the `master` branch.

### Detailed summary
- Created a new workflow file: `.github/workflow/codecov.yml`
- Defined a workflow named `codecov`
- Triggered on `push` and `pull_request` events for the `master` branch
- Set up a job `codecov` running on `ubuntu-20.04`
- Included steps for:
  - Checking out the repository
  - Setting up Java with `temurin` distribution and version 17
  - Caching Maven dependencies
  - Running `mvn clean install`
  - Uploading coverage reports to Codecov using the specified token and report file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->