### PR TITLE
#3 Fix

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,5 +32,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./build/jacocoHtml/index.html
+          files: ./build/reports/jacoco/test/jacocoTestReport.xml
           fail_ci_if_error: false

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,5 +32,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./build/reports/jacoco/test/html/index.html
+          files: ./build/jacocoHtml/index.html
           fail_ci_if_error: false

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ test {
 
 jacocoTestReport {
     reports {
-        xml.required = false
+        xml.required = true
         csv.required = false
         html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the JaCoCo test report configuration in `build.gradle` to enable XML report generation and updates the Codecov workflow to use the XML report file instead of the HTML report.

### Detailed summary
- In `build.gradle`, changed `xml.required` from `false` to `true`.
- In `.github/workflows/codecov.yml`, updated the `files` path from `./build/reports/jacoco/test/html/index.html` to `./build/reports/jacoco/test/jacocoTestReport.xml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->